### PR TITLE
WIP: Some analysis of new vscript

### DIFF
--- a/public/vscript/ivscript_handles.h
+++ b/public/vscript/ivscript_handles.h
@@ -1,0 +1,76 @@
+
+#ifndef IVSCRIPT_HANDLES_H
+#define IVSCRIPT_HANDLES_H
+
+#include "public/vscript/ivscript.h"
+
+class BaseScriptHandle
+{
+public:
+    BaseScriptHandle(IScriptVM *pVM, HSCRIPT handle)
+        m_pScriptVM(pVM),
+        m_Handle(handle)
+    {
+
+    }
+
+    bool Equals(BaseScriptHandle* other)
+    {
+        return m_pScriptVM.AreHandlesEqual(m_Handle, other->m_Handle);
+    }
+
+    //  Returns true if the handle is still alive.
+    bool IsValid()
+    {
+        return m_Handle != INVALID_HANDLE;
+    }
+
+    //  Take a reference of this handle.
+    //  If handle is invalid, then this will return null.
+    template <class T>
+    T* Reference()
+    {
+        if (m_Handle == INVALID_HANDLE)
+            return nullptr;
+
+        return new BaseScriptHandle(m_pScriptVM, m_pScriptVM.CopyHandle(m_Handle));
+    }
+
+    //  Free this handle and disable the handle
+    void Release()
+    {
+        if (m_Handle == INVALID_HANDLE)
+            return;
+
+        m_pScriptVM.ReleaseScript(m_Handle);
+        m_Handle = INVALID_HANDLE;
+    }
+protected:
+    IScriptVM *m_pScriptVM;
+    HSCRIPT m_Handle;
+};
+
+class TableHandle: public BaseScriptHandle
+{
+public:
+    int	CountTableEntries()
+    {
+        return m_pScriptVM.GetNumTableEntries(m_Handle);
+    }
+    int CountElements()
+    {
+        return m_pScriptVM.GetNumElements(m_Handle);
+    }
+
+    bool GetValue(int nIndex, ScriptVariant_t *pValue )
+    {
+        return m_pScriptVM.GetValue(m_Handle, nIndex, pValue);
+    }
+    
+    bool GetValue(const char *pszKey, ScriptVariant_t *pValue )
+    {
+        return m_pScriptVM.GetValue(m_Handle, pszKey, pValue);
+    }
+};
+
+#endif // IVSCRIPT_HANDLES_H


### PR DESCRIPTION
- Validated IScriptVM vtable
- Lots of new variants, haven't added those yet
- Added ramblings about lua runtime
- Added a little bit more documentation to existing funcs
- ScriptVariant_t seems to be the same
- Other structs not fully validated

Current recovered variants:
```c
enum ScriptDeduceType
{
    Void = 0x0,
    Float = 0x1,
    String_t = 0x2,
    Vector = 0x3,
    Quaternion = 0x4,
    Integer = 0x5,
    Boolean = 0x6,
    Char = 0x8,
    Color = 0x9,
    EHandle = 0xd,
    Vector2D = 0x19,
    Int64 = 0x1a,
    Vector4D = 0x1b,
    ResourceHandle = 0x1c,
    CString = 0x1e,
    HScript = 0x1f,
    Variant = 0x20, // <-- hmm
    UInt64 = 0x21,
    Float64 = 0x22,
    UInteger = 0x25,
    UtlStringToken = 0x26,
    QAngle = 0x27,
    HScriptLightBinding = 0x30,
    JS_Value = 0x31, // <-- hmmmmmm
    JS_Object = 0x32,
    JS_Array = 0x33,
    JS_Raw_Args = 0x34,
    MaxDeduce = 0x3a,
};
```